### PR TITLE
Fix user repository injection and repo parameter

### DIFF
--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/TournamentParticipantRepository.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/TournamentParticipantRepository.java
@@ -11,6 +11,6 @@ public interface TournamentParticipantRepository extends JpaRepository<Tournamen
 
     List<TournamentParticipant> findByGroupId(Long groupId);
 
-    TournamentParticipant findByUserId(Long groupId);
+    TournamentParticipant findByUserId(Long userId);
 
 }

--- a/src/main/java/com/dreamgames/backendengineeringcasestudy/TournamentService.java
+++ b/src/main/java/com/dreamgames/backendengineeringcasestudy/TournamentService.java
@@ -20,6 +20,7 @@ public class TournamentService {
     @Autowired
     private TournamentParticipantRepository participantRepository;
 
+    @Autowired
     private UserRepository userRepository;
 
     public TournamentGroup enterTournament(Long userId) {


### PR DESCRIPTION
## Summary
- inject `UserRepository` in `TournamentService`
- correct parameter name in `TournamentParticipantRepository.findByUserId`

## Testing
- `mvn -q test` *(fails: `command not found: mvn`)*

------
https://chatgpt.com/codex/tasks/task_e_6878cd609e188326ae165ac7a5625356